### PR TITLE
Fix landing docstring typo

### DIFF
--- a/RAD/modules/classes/planeInfo/landing.py
+++ b/RAD/modules/classes/planeInfo/landing.py
@@ -1,5 +1,5 @@
 class Landing:
-    '''Lainding object containing VAT, APC, and Distance data.'''
+    '''Landing object containing VAT, APC, and Distance data.'''
     def __init__(self, vat: int, distance: int):
         '''Initializes Landing object.'''
         self.vat: int = vat


### PR DESCRIPTION
## Summary
- fix spelling of 'Landing' in planeInfo/landing.py docstring

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68584324299c832580fa9aa0a684e990