### PR TITLE
Remove star imports from packages

### DIFF
--- a/RAD/modules/__init__.py
+++ b/RAD/modules/__init__.py
@@ -1,5 +1,74 @@
-from .classes import *
-from .frames import *
-from .models import *
+"""Aggregate exports from subpackages for convenient access."""
 
-__all__ = []
+from .classes import (
+    Aircraft,
+    Approach,
+    Cruise,
+    Flight_level,
+    Landing,
+    Take_off,
+    Technical,
+    User,
+)
+from .frames import (
+    AccountMenu,
+    AircraftMenu,
+    MainMenu,
+    PlaneCreator,
+    PlaneManager,
+)
+from .models import (
+    add_plane,
+    add_user,
+    boot_parts,
+    boot_plane,
+    boot_user,
+    delete_parts,
+    delete_plane,
+    delete_user,
+    get_parts,
+    get_specific_part,
+    insert_part,
+    search_plane,
+    search_user,
+    update_parts,
+    update_user,
+    view_planes,
+    view_users,
+)
+
+__all__ = [
+    # classes
+    "Aircraft",
+    "Approach",
+    "Cruise",
+    "Flight_level",
+    "Landing",
+    "Take_off",
+    "Technical",
+    "User",
+    # frames
+    "AccountMenu",
+    "AircraftMenu",
+    "MainMenu",
+    "PlaneCreator",
+    "PlaneManager",
+    # models
+    "add_plane",
+    "add_user",
+    "boot_parts",
+    "boot_plane",
+    "boot_user",
+    "delete_parts",
+    "delete_plane",
+    "delete_user",
+    "get_parts",
+    "get_specific_part",
+    "insert_part",
+    "search_plane",
+    "search_user",
+    "update_parts",
+    "update_user",
+    "view_planes",
+    "view_users",
+]

--- a/RAD/modules/classes/__init__.py
+++ b/RAD/modules/classes/__init__.py
@@ -1,5 +1,23 @@
-from .aircraft import Aircraft
-from .planeInfo import *
-from .user import User
+"""Expose class level symbols for the :mod:`modules.classes` package."""
 
-__all__ = ["Aircraft","Approach","Cruise","Flight_level","Landing","Take_off","Technical","User"]
+from .aircraft import Aircraft
+from .user import User
+from .planeInfo import (
+    Approach,
+    Cruise,
+    Flight_level,
+    Landing,
+    Take_off,
+    Technical,
+)
+
+__all__ = [
+    "Aircraft",
+    "Approach",
+    "Cruise",
+    "Flight_level",
+    "Landing",
+    "Take_off",
+    "Technical",
+    "User",
+]

--- a/RAD/modules/models/__init__.py
+++ b/RAD/modules/models/__init__.py
@@ -1,5 +1,45 @@
-from .aircraft import *
-from .planedata import *
-from .users import *
+"""Expose database helper functions for the :mod:`modules.models` package."""
 
-__all__ = ['add_plane', 'add_user', 'boot_parts', 'boot_plane', 'boot_user', 'delete_parts', 'delete_plane', 'delete_user', 'get_parts', 'get_specific_part', 'insert_part', 'search_plane', 'search_user', 'update_parts', 'update_user', 'view_planes', 'view_users']
+from .aircraft import (
+    boot_plane,
+    add_plane,
+    view_planes,
+    search_plane,
+    delete_plane,
+)
+from .planedata import (
+    boot_parts,
+    insert_part,
+    get_parts,
+    get_specific_part,
+    update_parts,
+    delete_parts,
+)
+from .users import (
+    boot_user,
+    add_user,
+    view_users,
+    search_user,
+    update_user,
+    delete_user,
+)
+
+__all__ = [
+    'boot_plane',
+    'add_plane',
+    'view_planes',
+    'search_plane',
+    'delete_plane',
+    'boot_parts',
+    'insert_part',
+    'get_parts',
+    'get_specific_part',
+    'update_parts',
+    'delete_parts',
+    'boot_user',
+    'add_user',
+    'view_users',
+    'search_user',
+    'update_user',
+    'delete_user',
+]


### PR DESCRIPTION
## Summary
- refactor `RAD/modules` package exports to avoid wildcard imports
- tidy up `modules/classes` and `modules/models` to explicitly re-export symbols

## Testing
- `python3 -m compileall -q RAD` *(fails: SyntaxError in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_685842e89c348325b0f0027f3c955842