### PR TITLE
Fix WTC classification in takeoff

### DIFF
--- a/RAD/modules/classes/planeInfo/takeoff.py
+++ b/RAD/modules/classes/planeInfo/takeoff.py
@@ -20,7 +20,7 @@ class Take_off:
                 return 'L'
             elif mtow < 136000:
                 return 'M'
-            elif mtow >= 13600:
+            else:
                 return 'H'
         except Exception as e:
             print(f'Error {e} on WTC calculus.')


### PR DESCRIPTION
## Summary
- fix typo in WTC classification so heavy aircraft are correctly detected

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: invalid decimal literal in `aircraftmenu.py`)*

------
https://chatgpt.com/codex/tasks/task_e_6858404bbb0083259ae3dc71d06ad354