### PR TITLE
Fix login username error alert

### DIFF
--- a/RAD/modules/service.py
+++ b/RAD/modules/service.py
@@ -184,7 +184,7 @@ class DatabaseService:
                 return user
             messagebox.showerror('Alert', 'Invalid Password')
             return None
-        messagebox.showerror('Invalid Username')
+        messagebox.showerror('Alert', 'Invalid Username')
         return None
 
     def register(self, name: str, password: str) -> bool:


### PR DESCRIPTION
## Summary
- show error message consistently on invalid username

## Testing
- `pytest -q` *(fails: Technical.__init__() got unexpected keyword argument 'wingposition')*

------
https://chatgpt.com/codex/tasks/task_e_68584844505083259c708274415f227c