### PR TITLE
Fix account menu callbacks

### DIFF
--- a/RAD/modules/frames/accountmenu.py
+++ b/RAD/modules/frames/accountmenu.py
@@ -43,14 +43,15 @@ class AccountMenu:
 
     def login(self):
         self.button_callback(self.ent_nickname.get(), self.ent_password.get())
-        self.on_close
+        self.on_close()
     def register(self):
         self.button_callback(self.ent_nickname.get(), self.ent_password.get())
-        self.on_close
+        self.on_close()
     
     def on_close(self):
         try:
-            self.on_close_callback(self.sender)
+            if self.on_close_callback:
+                self.on_close_callback()
         except Exception as e:
             print(f'Error {e} when emitting close signal.')
         self.root.destroy()

--- a/RAD/modules/frames/mainmenu.py
+++ b/RAD/modules/frames/mainmenu.py
@@ -43,10 +43,10 @@ class MainMenu:
     def open_manager(self):
         self.manager_callback()
     def open_register(self):
-        self.disable_buttons
+        self.disable_buttons()
         AccountMenu(self.root, self.reenable_buttons, self.register_callback).open_tab(False)
     def open_login(self):
-        self.disable_buttons
+        self.disable_buttons()
         AccountMenu(self.root, self.reenable_buttons, self.login_callback).open_tab(True)
     def do_login(self,user: str, password: str):
         if self.login_callback(user,password) == True:


### PR DESCRIPTION
## Summary
- disable buttons when opening login/register dialogs
- ensure account menu closes correctly
- remove invalid parameter when calling on_close callback

## Testing
- `pytest -q` *(fails: Technical.__init__() got an unexpected keyword argument 'wing_position')*

------
https://chatgpt.com/codex/tasks/task_e_68584adec9788325a39f806e71b10088